### PR TITLE
Add php extensions present in the Ubuntu precise 12.04 image

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,5 +66,5 @@ RUN fpm -s dir -t deb -C ${prefix}/${package}/${version} \
 Once you created src/Dockerfile, you can run `build-package` script from the top directory.
 
 ```
-./build-package ruby 2.2.2
+./build-package ruby 2.2.2 1 /opt/circleci/ruby/2.2.2
 ```

--- a/circle.yml
+++ b/circle.yml
@@ -18,7 +18,7 @@ machine:
 
     python_release:   1
     ruby_release:     1
-    php_release:      3
+    php_release:      4
     nodejs_release:   1
 
 dependencies:

--- a/php/src/Dockerfile
+++ b/php/src/Dockerfile
@@ -5,7 +5,7 @@ ARG release
 ARG install_dir
 RUN mkdir -p ${install_dir}
 
-ENV deps "libpng12-dev re2c m4 libxslt1-dev libjpeg-dev libxml2-dev libtidy-dev libmcrypt-dev libreadline-dev libmagic-dev libssl-dev libcurl4-openssl-dev libfreetype6-dev libapache2-mod-php5 libicu-dev apache2-dev autoconf"
+ENV deps "libpng12-dev re2c m4 libxslt1-dev libjpeg-dev libxml2-dev libtidy-dev libmcrypt-dev libreadline-dev libmagic-dev libssl-dev libcurl4-openssl-dev libfreetype6-dev libapache2-mod-php5 libicu-dev libgmp-dev libbz2-dev apache2-dev autoconf"
 
 RUN apt-get update && apt-get -y install $deps
 
@@ -21,6 +21,15 @@ RUN sed -i -e '1iwith_apxs2 "/usr/bin/apxs2"' /usr/local/share/php-build/definit
 # Enabling intl
 # Customer request: https://discuss.circleci.com/t/ubuntu-trusty-has-no-pecl-support-under-php7/3700/10
 RUN echo '--enable-intl' | tee -a /usr/local/share/php-build/default_configure_options
+
+# Enabling pdo_pgsql
+# Customer request: https://discuss.circleci.com/t/ubuntu-trusty-doesnt-have-pdo-pgsql/4001
+RUN echo '--with-pdo-pgsql' | tee -a /usr/local/share/php-build/default_configure_options
+
+# Enabling previously enabled options
+RUN echo '--with-gmp' '--enable-calendar' '--with-bz2' '--with-exif' '--with-gettext' '--enable-phar' '--with-pear' | tee -a /usr/local/share/php-build/default_configure_options
+
+RUN ln -s /usr/include/x86_64-linux-gnu/gmp.h /usr/include/gmp.h
 
 RUN php-build -i development ${version} ${install_dir}
 


### PR DESCRIPTION
Discussion: https://discuss.circleci.com/t/ubuntu-trusty-doesnt-have-pdo-pgsql/4001

I've added the extensions which were present on the Ubuntu 12.04 image, but are no longer present.
